### PR TITLE
Fix README merge conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-<<<<<<< HEAD
-# Bibou app pour Boubi 
-=======
 # Bibou app pour Boubi
->>>>>>> b420f994578d6c5dfa000ebcabc0774387f191c2
+
+Cette application React fournit des questionnaires quotidiens pour s'entraîner.
+Lancez `npm run dev` après installation des dépendances pour démarrer le projet.


### PR DESCRIPTION
## Summary
- fix leftover merge conflict markers in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840810d63148325835eab3d81f82fa9